### PR TITLE
fix(apps): Seperated AngularJS from Angular

### DIFF
--- a/tools/apps.md
+++ b/tools/apps.md
@@ -2,7 +2,8 @@
 
 ##### Front-End App Frameworks: [^1]
 
-* [AngularJS](https://angularjs.org/) + [angular-cli](https://github.com/angular/angular-cli) + [Batarang](https://github.com/angular/angularjs-batarang)
+* [AngularJS](https://github.com/angular/angular.js) + [Batarang](https://github.com/angular/angularjs-batarang)
+* [Angular](https://github.com/angular/angular) + [angular-cli](https://github.com/angular/angular-cli) 
 * [Aurelia](http://aurelia.io/) + [Aurelia CLI](https://github.com/aurelia/cli)
 * [Ember](http://emberjs.com/) + [embercli](https://ember-cli.com/) + [Ember Inspector](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi?hl=en)
 * [Polymer](https://www.polymer-project.org/1.0/)


### PR DESCRIPTION
Seperated AngularJS from Angular, as previously it was confusing because Batarang is to be used with AngularJS whereas Angular-cli is to be used with Angular. But Angular itself wasn't even mentioned in the list, only AngularJS was.