### PR TITLE
Change link on Learn From page to point at Newsletters, News, and Podcasts page

### DIFF
--- a/learning/learn-from.md
+++ b/learning/learn-from.md
@@ -1,3 +1,3 @@
 # Front-End Developers to Learn From
 
-The notion that you should follow an individual to learn about front-end development is slowly becoming pointless. The advanced practitioners of front-end development generate enough content that you can simply follow the community/leaders by paying attention to the front-end "news" outlets (via [Newsletters, News outlet, & Podcasts](https://frontendmasters.gitbooks.io/front-end-handbook-2017/content/learning/learn-from.html)).
+The notion that you should follow an individual to learn about front-end development is slowly becoming pointless. The advanced practitioners of front-end development generate enough content that you can simply follow the community/leaders by paying attention to the front-end "news" outlets (via [Newsletters, News, & Podcasts](https://frontendmasters.gitbooks.io/front-end-handbook-2017/content/learning/news-podcasts.html)).


### PR DESCRIPTION
PR for [issue 19](https://github.com/FrontendMasters/front-end-handbook-2017/issues/19). This could very well be working as intended, in which case reject and close issue.