### PR TITLE
Link to Yarn Scripts Had Wrong Format

### DIFF
--- a/tools/task.md
+++ b/tools/task.md
@@ -15,7 +15,7 @@
 
 ###### ADVICE:
 
-[^1] Before reaching for Gulp make sure [npm scripts](https://docs.npmjs.com/misc/scripts) or (yarn script)[https://yarnpkg.com/en/docs/package-json#toc-scripts] won't fit the bill. Read, ["Why I Left Gulp and Grunt for npm Scripts"](https://medium.freecodecamp.com/why-i-left-gulp-and-grunt-for-npm-scripts-3d6853dd22b8#.nw3huib54).
+[^1] Before reaching for Gulp make sure [npm scripts](https://docs.npmjs.com/misc/scripts) or [yarn script](https://yarnpkg.com/en/docs/package-json#toc-scripts) won't fit the bill. Read, ["Why I Left Gulp and Grunt for npm Scripts"](https://medium.freecodecamp.com/why-i-left-gulp-and-grunt-for-npm-scripts-3d6853dd22b8#.nw3huib54).
 
 ***
 


### PR DESCRIPTION
The markdown wrapping the Yarn scripts link had the parenthesis and square brackets swapped