### PR TITLE
Update links and grammar in Recap

### DIFF
--- a/recap.md
+++ b/recap.md
@@ -20,18 +20,18 @@
 * More developers start caring about tooling (e.g. automation) and testing.
 * [Static site generators](https://www.staticgen.com/) are [taken](https://github.com/vigetlabs/gulp-starter/tree/blendid) [seriously](https://phenomic.io/).
 * [CSS Grid excitement grows](http://meyerweb.com/eric/thoughts/2016/12/05/css-grid/) and the future looks bright.
-* [NPM](https://www.nasdaqprivatemarket.com/) gets some competition from [YARN](https://yarnpkg.com/).
+* [NPM](https://www.npmjs.com/) gets some competition from [Yarn](https://yarnpkg.com/).
 * The next evolution of React-like solutions shows up via [Preact](https://preactjs.com/), [Deku](https://github.com/anthonyshort/deku), [Rax](https://github.com/alibaba/rax), and [inferno](https://infernojs.org/) showcasing evolution without much API change.
-* Mostly people learn to not only accept [JSX](https://facebook.github.io/jsx/) they can't imagine not using it.
+* Mostly people learn to accept [JSX](https://facebook.github.io/jsx/), and now they can't imagine not using it.
 * A workable CSS module pattern (CSS encapsulation) is actualized and used, thus [CSS in JS](https://github.com/MicheleBertoli/css-in-js) becomes a viable solution for many.
 * More people turning to UI functional/integration testing including concepts like visual [CSS](https://css-tricks.com/automating-css-regression-testing/) & RWD regression testing.
 * The days of [battling](https://kangax.github.io/compat-table/es6/) [inconsistent browser API's](https://html5test.com/results/desktop.html) are almost behind us due to a massive decline in usage and development for [older versions of IE](https://www.netmarketshare.com/browser-market-share.aspx?qprid=2&qpcustomd=0).
-* Most everyone realized they will have to have a [multi-device strategy](http://www.intel.com/content/dam/www/public/us/en/images/iot/guide-to-iot-infographic.png) plan when development for the web
-* More developer, from other languages, continue to flood the JavaScript space bringing with them things like [type checking](https://flowtype.org/) and an [obsession with class syntax and OOP concepts](https://www.typescriptlang.org/).
+* Most everyone realized they will have to have a [multi-device strategy](http://www.intel.com/content/dam/www/public/us/en/images/iot/guide-to-iot-infographic.png) plan when developing for the web
+* More developers, from other languages, continue to flood the JavaScript space bringing with them things like [type checking](https://flowtype.org/) and an [obsession with class syntax and OOP concepts](https://www.typescriptlang.org/).
 * Front-end devs are introduced to [Hot Module replacement techniques and time travel debugging](https://code-cartoons.com/hot-reloading-and-time-travel-debugging-what-are-they-3c8ed2812f35#.ezlpqez1i).
 * More waiting for a native [JavaScript browser module loader](https://whatwg.github.io/loader/).
 * [Enforcing CSS](https://css-tricks.com/stylelint/) and [JavaScript style conventions](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb) becomes more important (considering ES3 to ES6 code and CSS pre-processors syntactical variations)
-* A small but noticeable number of developers are starting to [chose Elm over JavaScript](https://www.brianthicks.com/post/2016/04/22/state-of-elm-2016-results/).
+* A small but noticeable number of developers are starting to [choose Elm over JavaScript](https://www.brianthicks.com/post/2016/04/22/state-of-elm-2016-results/).
 * [TypeScript](https://www.typescriptlang.org/) gets some serious use and fanboys.
 * http://aurelia.io/ becomes the [smart choice for enterprise developers](https://www.youtube.com/watch?v=6I_GwgoGm1w&t=3315s) (i.e. support!).
 * [Webpack](https://webpack.js.org/configuration/) gets its act [together](https://opencollective.com/webpack) and solidifies is position over the superior [JSPM](https://www.pluralsight.com/courses/javascript-systemjs-jspm) solution.


### PR DESCRIPTION
Link to NPM website instead of [NASDAQ Private Market](https://www.nasdaqprivatemarket.com) (unless I missed a joke 🙃).
Make Yarn correct case.
Change wording on JSX line to be more readable.
Fix minor misspellings and grammatical errors