### PR TITLE
Add mitmproxy to tools/http.md

### DIFF
--- a/tools/http.md
+++ b/tools/http.md
@@ -3,6 +3,7 @@
 * [Charles](http://www.charlesproxy.com/) [$]
 * [Chrome DevTools Network Panel](https://developers.google.com/web/tools/chrome-devtools/profile/network-performance/resource-loading)
 * [Insomnia](https://insomnia.rest/) [free - $]
+* [Mitmproxy](https://mitmproxy.org/) [free]
 * [Paw](https://paw.cloud/) [$]
 * [Postman](https://www.getpostman.com/) [free - $]
 


### PR DESCRIPTION
The handbook is fantastic, but was missing mitmproxy. Slainte! :)  