### PR TITLE
Add Friday Front-end newsletter

### DIFF
--- a/learning/news-podcasts.md
+++ b/learning/news-podcasts.md
@@ -4,6 +4,7 @@
 
 * [The Big Web Show](http://5by5.tv/bigwebshow)
 * [Dev Tips](https://umaar.com/dev-tips/)
+* [Friday Front-End](https://zendev.com/friday-frontend.html)
 * [Front-End Dev Weekly](http://frontenddevweekly.com/)
 * [Front End Happy Hour](http://frontendhappyhour.com/)
 * [Front-End News in 5 Minutes](https://frontendfive.codeschool.com/)


### PR DESCRIPTION
Adds the ZenDev Friday Front-end newsletter to the general Frontend Newsletters section. Full disclosure: I publish this newsletter, so you may want to independently validate the quality. Archives link is here: https://zendev.com/category/friday-frontend.html