### PR TITLE
Correct url

### DIFF
--- a/2017.md
+++ b/2017.md
@@ -13,7 +13,7 @@
 * More people will move from Sass to [PostCSS](http://postcss.org/) + cssnext.
 * Lots more HTTP2 and HTTPS.
 * Web components will continue to lurk and wait for significant traction by developers that might never come to be.
-* The no framework, framework, faction will gain momentum (see [Svelte](https://svelte.technology/blog/frameworks-without-the-framework/)).
+* The no framework, framework, faction will gain momentum (see [Svelte](https://svelte.technology/blog/frameworks-without-the-framework)).
 * JavaScript will settle, and hopefully, CSS will erupt and everyone will cry fatigue until it settles.
 * Hatred for apps store will grow, while the open web has no memory of wrong doing.
 * Redux will continue to get stiff competition (see [mobx](https://mobx.js.org/)).


### PR DESCRIPTION
Removed the trailing slash from Svelte url otherwise it 404s.